### PR TITLE
Cursor movement

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,13 @@ fn input_normal_mode(s: &mut Screen, k: KeyEvent) {
             KeyCode::Char('i') => {
                 s.e.insert_mode();
             }
+			KeyCode::Down |
             KeyCode::Char('j') => s.move_down(),
+			KeyCode::Up |
             KeyCode::Char('k') => s.move_up(),
+			KeyCode::Left |
             KeyCode::Char('h') => s.move_left(),
+			KeyCode::Right |
             KeyCode::Char('l') => s.move_right(),
             _ => {}
         },
@@ -87,6 +91,12 @@ fn input_insert_mode(s: &mut Screen, k: KeyEvent) {
         } => s.e.normal_mode(),
         KeyEvent { code, .. } => {
             match code {
+                // Cursor movement
+                KeyCode::Up => s.move_up(),
+                KeyCode::Down => s.move_down(),
+                KeyCode::Left => s.move_left(),
+                KeyCode::Right => s.move_right(),
+
                 KeyCode::Enter => {
                     // new line
                     s.line_break();

--- a/src/textbuffer.rs
+++ b/src/textbuffer.rs
@@ -52,6 +52,10 @@ impl TextBuffer {
         self.text.line(idx)
     }
 
+    pub fn line_len(&self, idx: usize) -> u16 {
+        self.text.line(idx as usize).as_str().unwrap().trim_end_matches("\n").trim_end_matches("\r").len() as u16
+    }
+
     pub fn bytes<'a>(&'a self) -> Bytes<'a> {
         self.text.bytes()
     }


### PR DESCRIPTION
Overhauled cursor movement
- Added checks to only allow cursor where text is
- Added line wrapping for the cursor
- Added allowing the cursor to stick to the ends of lines while moving up and down
- Added arrow key support 