### PR TITLE
Fix Issue #16

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -248,7 +248,7 @@ impl Screen {
         for i in start..self.dim.h - 2 {
             queue!(
                 self.w,
-                cursor::MoveToNextLine(1),
+                cursor::MoveTo(0, i),
                 style::Print('~')
             ).unwrap();
         }


### PR DESCRIPTION
This changes cursor::MoveToNextLine() to cursor::MoveTo() in screen.render_empty_lines() in order to avoid using the cursor position to choose where to draw the ~ which fixes #16 

We could still use MoveToNextLine by moving the cursor to where ever the ~ start at the beginning of render_empty_lines() but I don't think there is any efficiency saved by doing that so I'm just changing it to MoveTo()